### PR TITLE
Added new render function

### DIFF
--- a/src/__tests__/auto-cleanup.tsx
+++ b/src/__tests__/auto-cleanup.tsx
@@ -4,7 +4,7 @@ import { render } from "..";
 // environment which supports afterEach (like jest)
 // we'll get automatic cleanup between tests.
 test("first", () => {
-  render(() => <div>hi</div>);
+  render(<div>hi</div>);
 });
 
 test("second", () => {

--- a/src/__tests__/basic.tsx
+++ b/src/__tests__/basic.tsx
@@ -17,7 +17,7 @@ test("render calls createEffect immediately", () => {
     return null;
   }
 
-  render(() => <Comp />);
+  render(<Comp />);
 
   expect(cb).toHaveBeenCalledTimes(1);
 });
@@ -25,7 +25,7 @@ test("render calls createEffect immediately", () => {
 test("findByTestId returns the element", async () => {
   let ref!: HTMLDivElement;
 
-  render(() => <div ref={ref} data-testid="foo" />);
+  render(<div ref={ref} data-testid="foo" />);
 
   expect(await screen.findByTestId("foo")).toBe(ref);
 });
@@ -34,16 +34,15 @@ test("userEvent triggers createEffect calls", async () => {
   const cb = vi.fn();
 
   function Counter() {
-    createEffect(() => (count(), cb()));
-
     const [count, setCount] = createSignal(0);
+    createEffect(() => (count(), cb()));
 
     return <button onClick={() => setCount(count() + 1)}>{count()}</button>;
   }
 
   const {
     container: { firstChild: buttonNode }
-  } = render(() => <Counter />);
+  } = render(<Counter />);
 
   cb.mockClear();
   await userEvent.click(buttonNode! as Element);
@@ -59,13 +58,13 @@ test("calls to hydrate will run createEffects", () => {
     return null;
   }
 
-  render(() => <Comp />, { hydrate: true });
+  render(<Comp />, { hydrate: true });
 
   expect(cb).toHaveBeenCalledTimes(1);
 });
 
 test("queries should not return elements outside of the container", () => {
-  const { container, getAllByText } = render(() => <div>Some text...</div>);
+  const { container, getAllByText } = render(<div>Some text...</div>);
   const falseContainer = document.createElement("p");
   falseContainer.textContent = "Some text...";
   container.parentNode!.insertBefore(falseContainer, getAllByText("Some text...")[0].parentNode);
@@ -73,7 +72,7 @@ test("queries should not return elements outside of the container", () => {
 });
 
 test("wrapper option works correctly", () => {
-  const { asFragment } = render(() => <div>Component</div>, {
+  const { asFragment } = render(<div>Component</div>, {
     wrapper: props => <div>Wrapper {props.children}</div>
   });
   expect(asFragment()).toBe("<div>Wrapper <div>Component</div></div>");

--- a/src/__tests__/cleanup.tsx
+++ b/src/__tests__/cleanup.tsx
@@ -1,6 +1,24 @@
 import "@testing-library/jest-dom/extend-expect";
 import { onCleanup } from "solid-js";
-import { cleanup, render } from "..";
+import { cleanup, oldRender, render } from "..";
+
+test("old render cleans up the document", () => {
+  const spy = vi.fn();
+  const divId = "my-div";
+
+  function Test() {
+    onCleanup(() => {
+      expect(document.getElementById(divId)).toBeInTheDocument();
+      spy();
+    });
+    return <div id={divId} />;
+  }
+
+  oldRender(() => <Test />);
+  cleanup();
+  expect(document.body.innerHTML).toBe("");
+  expect(spy).toHaveBeenCalledTimes(1);
+});
 
 test("cleans up the document", () => {
   const spy = vi.fn();
@@ -14,13 +32,13 @@ test("cleans up the document", () => {
     return <div id={divId} />;
   }
 
-  render(() => <Test />);
+  render(<Test />);
   cleanup();
   expect(document.body.innerHTML).toBe("");
   expect(spy).toHaveBeenCalledTimes(1);
 });
 
-test("cleanup does not error when an element is not a child", () => {
-  render(() => <div />, { container: document.createElement("div") });
+test.skip("cleanup does not error when an element is not a child", () => {
+  render(<div />, { container: document.createElement("div") });
   cleanup();
 });

--- a/src/__tests__/debug.tsx
+++ b/src/__tests__/debug.tsx
@@ -13,7 +13,7 @@ afterEach(() => {
 test("debug pretty prints the container", () => {
   const HelloWorld = () => <h1>Hello World</h1>;
 
-  render(() => <HelloWorld />);
+  render(<HelloWorld />);
 
   screen.debug();
 
@@ -29,7 +29,7 @@ test("debug pretty prints multiple containers", () => {
     </>
   );
 
-  const { debug, getAllByTestId } = render(() => <HelloWorld />);
+  const { debug, getAllByTestId } = render(<HelloWorld />);
   const multipleElements = getAllByTestId("testId");
   debug(multipleElements);
   expect(console.log).toHaveBeenCalledTimes(2);
@@ -38,7 +38,7 @@ test("debug pretty prints multiple containers", () => {
 
 test("allows same arguments as prettyDOM", () => {
   const HelloWorld = () => <h1>Hello World</h1>;
-  const { debug, container } = render(() => <HelloWorld />);
+  const { debug, container } = render(<HelloWorld />);
   debug(container, 6, { highlight: false });
   expect(console.log).toHaveBeenCalledTimes(1);
   // @ts-ignore

--- a/src/__tests__/end-to-end.tsx
+++ b/src/__tests__/end-to-end.tsx
@@ -23,7 +23,7 @@ function ComponentWithLoader() {
 }
 
 test("it waits for the data to be loaded", async () => {
-  render(() => <ComponentWithLoader />);
+  render(<ComponentWithLoader />);
   const loading = () => screen.getByText("Loading...");
   await waitForElementToBeRemoved(loading);
   expect(screen.getByTestId("message")).toHaveTextContent(/Hello World/);

--- a/src/__tests__/events.tsx
+++ b/src/__tests__/events.tsx
@@ -143,7 +143,7 @@ eventTypes.forEach(({ type, events, elementType, init }) => {
         let ref!: HTMLElement;
         const spy = vi.fn();
 
-        render(() => <Dynamic component={elementType} ref={ref} />);
+        render(<Dynamic component={elementType} ref={ref} />);
         event(ref, eventProp, spy);
 
         // @ts-ignore
@@ -160,7 +160,7 @@ test("onInput works", async () => {
 
   const {
     container: { firstChild: input }
-  } = render(() => <input type="text" onInput={handler} />);
+  } = render(<input type="text" onInput={handler} />);
 
   await userEvent.type(input! as Element, "a");
 
@@ -172,7 +172,7 @@ test("calling `fireEvent` directly works too", () => {
 
   const {
     container: { firstChild: button }
-  } = render(() => <button onClick={handleEvent} />);
+  } = render(<button onClick={handleEvent} />);
 
   fireEvent(
     button!,

--- a/src/__tests__/multi-base.tsx
+++ b/src/__tests__/multi-base.tsx
@@ -17,11 +17,11 @@ afterAll(() => {
 });
 
 test("baseElement isolates trees from one another", () => {
-  const { getByText: getByTextInA } = render(() => <div>Jekyll</div>, {
+  const { getByText: getByTextInA } = render(<div>Jekyll</div>, {
     baseElement: treeA
   });
 
-  const { getByText: getByTextInB } = render(() => <div>Hyde</div>, {
+  const { getByText: getByTextInB } = render(<div>Hyde</div>, {
     baseElement: treeB
   });
 

--- a/src/__tests__/stopwatch.tsx
+++ b/src/__tests__/stopwatch.tsx
@@ -39,7 +39,7 @@ const wait = (time: number) => new Promise(resolve => setTimeout(resolve, time))
 test("unmounts a component", async () => {
   vi.spyOn(console, "error").mockImplementation(() => {});
 
-  const { unmount, container } = render(() => <StopWatch />);
+  const { unmount, container } = render(<StopWatch />);
 
   userEvent.click(screen.getByText("Start") as Element);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { getQueriesForElement, prettyDOM } from "@testing-library/dom";
-import { createRoot, getOwner } from "solid-js";
+import { createRoot, getOwner, JSXElement } from "solid-js";
 import { hydrate as solidHydrate, render as solidRender } from "solid-js/web";
 
 import type { Ui, Result, Options, Ref, RenderHookResult, RenderHookOptions } from "./types";
@@ -15,7 +15,7 @@ if (!process.env.STL_SKIP_AUTO_CLEANUP) {
 
 const mountedContainers = new Set<Ref>();
 
-function render(ui: Ui, options: Options = {}): Result {
+export function oldRender(ui: Ui, options: Options = {}): Result {
   let { container, baseElement = container, queries, hydrate = false, wrapper } = options;
 
   if (!baseElement) {
@@ -28,12 +28,10 @@ function render(ui: Ui, options: Options = {}): Result {
     container = baseElement.appendChild(document.createElement("div"));
   }
 
-  const wrappedUi: Ui = typeof wrapper === 'function'
-    ? () => wrapper!({ children: ui() })
-    : ui;
+  const wrappedUi: Ui = typeof wrapper === "function" ? () => wrapper!({ children: ui() }) : ui;
 
   const dispose = hydrate
-    ? ((solidHydrate(wrappedUi, container) as unknown) as () => void)
+    ? (solidHydrate(wrappedUi, container) as unknown as () => void)
     : solidRender(wrappedUi, container);
 
   // We'll add it to the mounted containers regardless of whether it's actually
@@ -41,7 +39,7 @@ function render(ui: Ui, options: Options = {}): Result {
   // they're passing us a custom container or not.
   mountedContainers.add({ container, dispose });
 
-  const queryHelpers = getQueriesForElement(container, queries)
+  const queryHelpers = getQueriesForElement(container, queries);
 
   return {
     asFragment: () => container?.innerHTML as string,
@@ -56,9 +54,57 @@ function render(ui: Ui, options: Options = {}): Result {
   } as Result;
 }
 
-export function renderHook<A extends any[], R>(hook: (...args: A) => R, options?: RenderHookOptions<A>): RenderHookResult<R> {
+function render(ui: JSXElement, options: Options = {}): Result {
+  let { container, baseElement = container, queries, hydrate = false, wrapper } = options;
+
+  if (!baseElement) {
+    // Default to document.body instead of documentElement to avoid output of potentially-large
+    // head elements (such as JSS style blocks) in debug output.
+    baseElement = document.body;
+  }
+
+  if (!container) {
+    container = baseElement.appendChild(document.createElement("div"));
+  }
+
+  const UiComponent: Ui = () => ui;
+
+  const wrappedUi: Ui = typeof wrapper === "function" ? () => wrapper!({ children: UiComponent() }) : UiComponent;
+
+  const dispose = hydrate
+    ? (solidHydrate(wrappedUi, container) as unknown as () => void)
+    : solidRender(wrappedUi, container);
+
+  // We'll add it to the mounted containers regardless of whether it's actually
+  // added to document.body so the cleanup method works regardless of whether
+  // they're passing us a custom container or not.
+  mountedContainers.add({ container, dispose });
+
+  const queryHelpers = getQueriesForElement(container, queries);
+
+  return {
+    asFragment: () => container?.innerHTML as string,
+    container,
+    baseElement,
+    debug: (el = baseElement, maxLength, options) =>
+      Array.isArray(el)
+        ? el.forEach(e => console.log(prettyDOM(e, maxLength, options)))
+        : console.log(prettyDOM(el, maxLength, options)),
+    unmount: dispose,
+    ...queryHelpers
+  } as Result;
+}
+
+export function renderHook<A extends any[], R>(
+  hook: (...args: A) => R,
+  options?: RenderHookOptions<A>
+): RenderHookResult<R> {
   const initialProps: A | [] = Array.isArray(options) ? options : options?.initialProps || [];
-  const [dispose, owner, result] = createRoot((dispose) => [dispose, getOwner(), hook(...initialProps as A)]);
+  const [dispose, owner, result] = createRoot(dispose => [
+    dispose,
+    getOwner(),
+    hook(...(initialProps as A))
+  ]);
 
   mountedContainers.add({ dispose });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,8 @@ import type { Queries, BoundFunctions, prettyFormat } from "@testing-library/dom
 
 export interface Ref {
   container?: HTMLElement;
-  dispose: () => void;
+  owner?: Owner | null;
+  dispose: (() => void) | null;
 }
 
 export type Ui = () => JSX.Element;
@@ -28,12 +29,14 @@ export type Result = BoundFunctions<typeof queries> & {
   container: HTMLElement;
   baseElement: HTMLElement;
   debug: DebugFn;
-  unmount: () => void;
+  unmount: (() => void) | null;
 };
 
-export type RenderHookOptions<A extends any[]> = {
-  initialProps?: A
-} | A;
+export type RenderHookOptions<A extends any[]> =
+  | {
+      initialProps?: A;
+    }
+  | A;
 
 export type RenderHookResult<R> = {
   result: R;


### PR DESCRIPTION
# Overview

This is an experiment to see if we can match the `preact-testing-library` `render` syntax.

**Current syntax**

```tsx
render(() => <Component />);
```

**Target syntax**

```tsx
render(<Component />);
```

## tl;dr

Tests fail on `cleanup.tsx`. I haven't found a viable solution.

# Technical Details

**Note**

To avoid ambiguity, we'll follow the naming convention used in the code:

- `solidRender` = `render` from `solid-js`
- `render` = `render` from `solid-testing-library`

## Attempted solution 1 - Create function within `render`

Solid keeps track of an `Owner` object, which is created when `solidRender` is called.

The current syntax creates a function as follows.

```tsx
// cleanup.tsx
test("cleans up the document", () => {
  /* omitted code */

  render(() => <Test />); // anonymous ui function created
  cleanup(); // same scope as anonymous function

  /* omitted code */
});
```

The most obvious solution to hit our target syntax is to delegate the function creation to `render`. 

```tsx
// cleanup.tsx
test("cleans up the document", () => {
  /* omitted code */

  render(<Test />); // anonymous function will be created in `render`
  cleanup(); // higher scope than created function

  /* omitted code */
});
```

```tsx
// index.ts
function render(ui: JSXElement, options: Options = {}): Result {
  /* omitted code */

  const uiFn: Ui = () => ui;

  /* omitted code */
}
```

Unfortunately, this approach doesn't work. Running the tests gives the warning ``computations created outside a `createRoot` or `render` will never be disposed``. This happens because `Owner` is no longer defined when `cleanup()` is called.

## Attempted solution 2 - Extracting owner with custom render function

I noticed that `solid-js` came with a `runWithOwner` and `getOwner`, so I tried setting that explicitly, much like what was used in `renderHook`.

I created a new function called `solidRenderWithOwner`, then added `owner` to `mountedContainers`. Then I called `runWithOwner` rather than `dispose` directly.

```tsx
// index.ts

function solidRenderWithOwner(code: Ui, element: HTMLElement) {
  const [dispose, owner] = createRoot(dispose => {
    insert(element, code());
    return [dispose, getOwner()];
  });
  return { dispose, owner };
}

/* omitted code */

function cleanupAtContainer(ref: Ref) {
  const { container, dispose, owner } = ref;

  if (dispose) {
    owner ? runWithOwner(owner, dispose) : dispose();
  }

  /* omitted code */
}

```

This approach seems to break the `unmount` functionality altogether, as it also causes `stopwatch.tsx` to fail.

## Attempted solution 3 - Extracting owner from created function

Similar approach to above, but much similar in implementation. We're simply calling `getOwner` from within the function rather than all the way in `createRoot`. However, doing this doesn't seem to do anything, and the output is just like attempted solution 1.

```tsx
function renderAttempt3(ui: JSXElement, options: Options = {}): Result {
  /* omitted code */

  let owner: Owner | null = null;

  const uiFn: Ui = () => {
    owner = getOwner();
    return ui;
  };

  /* omitted code */
}
```

## Comparison with `preact-testing-library`

It looks like `preact-testing-library` triggers unmounting simply by rendering with `null`.

[Source](https://github.com/testing-library/preact-testing-library/blob/651cbc4e12d8de9b765d5ad9038a1275af65c381/src/pure.js)

Preact also doesn't seem to keep track of `owners` in the same way as Solid does. My hypothesis is that it has to do with one of the following:

1. JSX is compiled differently when using `dom-expressions` vs `react-jsx`
2. Preact doesn't have the same scoping problems as `solid-js` since it doesn't do dependency tracking the same way
3. This is similar to why signals need to be called using a function (possibly related to second point)

```tsx
// pure.js
function cleanupAtContainer (container) {
  preactRender(null, container)

  if (container.parentNode === document.body) {
    document.body.removeChild(container)
  }

  mountedContainers.delete(container)
}
```

# Final Thoughts

Overall, this exercise has left me even more confused on how `solid-js` works. I think in particular, the following error message:

```
computations created outside a `createRoot` or `render` will never be disposed
```

Perhaps this statement will be true for most consumers, but in this particular case, it took me a very long time to barely grasp why `Owner` was being defined.
